### PR TITLE
jx-cdx-spring-boot-demo-1 to 0.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: jx-cdx-spring-boot-demo-1
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.3
+  version: 0.0.4


### PR DESCRIPTION
Promote jx-cdx-spring-boot-demo-1 to version 0.0.4